### PR TITLE
Update upstream speedtest to v1.1.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/prometheus/client_golang v1.12.1
-	github.com/showwin/speedtest-go v1.1.4
+	github.com/showwin/speedtest-go v1.1.5
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/pflag v1.0.5
 	k8s.io/klog/v2 v2.40.1

--- a/go.sum
+++ b/go.sum
@@ -328,8 +328,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sagikazarmark/crypt v0.3.0/go.mod h1:uD/D+6UF4SrIR1uGEv7bBNkNqLGqUr43MRiaGWX1Nig=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
-github.com/showwin/speedtest-go v1.1.4 h1:pcY1W5LYZu44lH6Fuu80nu/Pj67n//VArlZudbAgR6E=
-github.com/showwin/speedtest-go v1.1.4/go.mod h1:dJugxvC/AQDt4HQQKZ9lKNa2+b1c8nzj9IL0a/F8l1U=
+github.com/showwin/speedtest-go v1.1.5 h1:dud1cS2Qppbm50BrTKzrBj78wY78ORL5LIiRjKexmdY=
+github.com/showwin/speedtest-go v1.1.5/go.mod h1:dJugxvC/AQDt4HQQKZ9lKNa2+b1c8nzj9IL0a/F8l1U=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=

--- a/pkg/speedtest/speedtest.go
+++ b/pkg/speedtest/speedtest.go
@@ -2,6 +2,7 @@ package speedtest
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	gospeedtest "github.com/showwin/speedtest-go/speedtest"
@@ -34,7 +35,7 @@ func (g *Speedtest) RunTest() error {
 	if err != nil {
 		return err
 	}
-	serverList, err := gospeedtest.FetchServerList(user)
+	serverList, err := gospeedtest.FetchServers(user)
 	if err != nil {
 		return err
 	}
@@ -42,6 +43,8 @@ func (g *Speedtest) RunTest() error {
 	if err != nil {
 		return err
 	}
+	// upstream String() includes \n, and it'd be better for output here if there weren't any \n
+	klog.V(2).Infof("Using server %s (hostname %s)", strings.ReplaceAll(targets[0].String(), "\n", ""), targets[0].Host)
 	g.TestStartTime = time.Now()
 	defer func() {
 		g.TestDuration = elapsed(g.TestStartTime)()


### PR DESCRIPTION
Running -v 2 will now print the server used:

```
Using server [serverid]     1.12km Location, Province (Country) by Sponsor (hostname sponsor.hostname.example.net:8080)
```

Signed-off-by: Lisa Seelye <lisa@users.noreply.github.com>