### PR TITLE
Add labels to container images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,18 @@ RUN apk --no-cache add ca-certificates
 RUN go mod download
 COPY . .
 RUN \
-  CGO_ENABLED=0 GOARCH=${GOARCH} go build -ldflags "-extldflags '-static' -X github.com/lisa/speedtest-go-exporter/pkg/version.GitHash=${GITHASH} -X github.com/lisa/speedtest-go-exporter/pkg/version.Version=${VERSIONSTRING}" -a -o /workdir/speedtest-exporter . && chmod +x /workdir/speedtest-exporter
+  CGO_ENABLED=0 GOARCH=${GOARCH} go build -ldflags "-extldflags '-static' -X github.com/lisa/speedtest-go-exporter/pkg/version.GitHash=${GITHASH} -X github.com/lisa/speedtest-go-exporter/pkg/version.Version=${VERSIONSTRING}" -a -o /workdir/speedtest-exporter . && \
+  chmod +x /workdir/speedtest-exporter
 
 FROM scratch
+
+ARG GOARCH
+ARG GITHASH
+ARG VERSIONSTRING
+
+LABEL GITHASH=${GITHASH}
+LABEL VERSIONSTRING=${VERSIONSTRING}
+LABEL org.opencontainers.image.authors="Lisa Seelye https://github.com/lisa/speedtest-go-exporter"
 
 COPY --from=builder /workdir/speedtest-exporter /
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,8 @@ $(BIN_FILE): test vet
 
 .PHONY: docker-build
 docker-build:
-	@for build_arch in $(ARCHES); do \
+	@echo "Building githash $(GITHASH) into version $(VERSION)" ;\
+	for build_arch in $(ARCHES); do \
 		docker build --platform=linux/$$build_arch --build-arg=GITHASH=$(GITHASH) --build-arg=VERSION=$(VERSION) --build-arg=GOARCH=$$build_arch -t $(REGISTRY)/$(IMG):$$build_arch-$(VERSION) . ;\
 		$(call set_image_arch,$(REGISTRY)/$(IMG):$$build_arch-$(VERSION),$$build_arch) ;\
 		if [[ $(TAG_LATEST) == "true" ]]; then \


### PR DESCRIPTION
This will help identify images in use at a glance, especially when
`latest` is used, which does not contain any version information. With
labels added to the image, one can inspect them to reveal what is in
use.

Signed-off-by: Lisa Seelye <lisa@users.noreply.github.com>